### PR TITLE
[27기 구유진] nav와header 컴포넌트 분리 nav sticky적용

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -5,12 +5,14 @@ import ProductList from './pages/ProductList/ProductList';
 import Cart from './pages/Cart/Cart';
 import Signin from './pages/Signin/Signin';
 import Signup from './pages/Signup/Signup';
+import Header from './components/Header/Header';
 import Nav from './components/Nav/Nav';
 import Footer from './components/Footer/Footer';
 
 function Router() {
   return (
     <BrowserRouter>
+      <Header />
       <Nav />
       <Routes>
         <Route path="/" element={<ProductList />} />

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './Header.scss';
+
+function Header() {
+  return (
+    <div className="header">
+      <header className="headerContainer">
+        <div className="join">
+          <Link className="joinSignup" to="/signup">
+            회원가입
+          </Link>
+          <Link className="joinSignin" to="/signin">
+            로그인
+          </Link>
+        </div>
+        <div className="navLogo">
+          <Link className="clickToMain" to="/">
+            <img
+              className="mainLog"
+              src="http://localhost:3000/images/brokurlylog.png"
+              alt="logo"
+            />
+          </Link>
+        </div>
+      </header>
+    </div>
+  );
+}
+
+export default Header;

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,0 +1,43 @@
+@import '../../styles/variables.scss';
+
+.header {
+  @include flexCenter;
+  min-width: 1050px;
+  padding: 20px 20px 0 20px;
+  background-color: $bg-white;
+
+  .headerContainer {
+    width: 100%;
+    max-width: 1010px;
+
+    .join {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+
+      .joinSignup {
+        padding: 0 10px;
+        color: $green;
+        border-right: 1px solid $border-gray;
+        font-weight: 600;
+      }
+
+      .joinSignin {
+        padding: 10px;
+        font-weight: 600;
+      }
+    }
+
+    .navLogo {
+      @include flexCenter;
+      padding: 0 10px;
+
+      .clickToMain {
+        .mainLog {
+          width: 100px;
+          height: 80px;
+        }
+      }
+    }
+  }
+}

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -9,26 +9,7 @@ import './Nav.scss';
 function Nav() {
   return (
     <div className="nav">
-      <header className="navContainer">
-        <div className="moveHeader">
-          <div className="join">
-            <Link className="joinSignup" to="/signup">
-              회원가입
-            </Link>
-            <Link className="joinSignin" to="/signin">
-              로그인
-            </Link>
-          </div>
-          <div className="navLogo">
-            <Link className="clickToMain" to="/">
-              <img
-                className="mainLog"
-                src="http://localhost:3000/images/brokurlylog.png"
-                alt="logo"
-              />
-            </Link>
-          </div>
-        </div>
+      <nav className="navContainer">
         <div className="stickyNav">
           <div className="categoryBar">
             <ul className="categoryList">
@@ -60,7 +41,7 @@ function Nav() {
             </Link>
           </div>
         </div>
-      </header>
+      </nav>
     </div>
   );
 }

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -2,45 +2,16 @@
 
 .nav {
   @include flexCenter;
+  position: sticky;
+  top: 0;
+  z-index: 1;
   min-width: 1050px;
-  padding: 20px 20px 10px 20px;
+  padding: 10px 20px;
   background-color: $bg-white;
 
   .navContainer {
     width: 100%;
     max-width: 1010px;
-
-    .moveHeader {
-      .join {
-        display: flex;
-        justify-content: flex-end;
-        align-items: center;
-
-        .joinSignup {
-          padding: 0 10px;
-          color: $green;
-          border-right: 1px solid $border-gray;
-          font-weight: 600;
-        }
-
-        .joinSignin {
-          padding: 10px;
-          font-weight: 600;
-        }
-      }
-
-      .navLogo {
-        @include flexCenter;
-        padding: 10px;
-
-        .clickToMain {
-          .mainLog {
-            width: 100px;
-            height: 80px;
-          }
-        }
-      }
-    }
 
     .stickyNav {
       display: flex;
@@ -64,6 +35,7 @@
           }
         }
       }
+
       .navSearch {
         @include flexCenter;
         width: 25%;
@@ -74,6 +46,7 @@
           padding: 10px;
           font-size: 15px;
         }
+
         .searchButton {
           border: 0;
           padding: 10px;
@@ -81,6 +54,7 @@
           font-size: 15px;
         }
       }
+
       .navIcon {
         font-size: 30px;
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- nav(카테고리)와header(회원가입.로그인과 로고이미지) 컴포넌트 분리하여 header sticky적용

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. nav와 header의 컴포넌트 분리
- nav와 header를 분리시킴으로서 nav에 sticky를 적용하여 스크롤시 페이지 상단에 고정이된다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 처음에는 nav 안에 카테고리를 만들어서 sticky를 적용하기가 힘들었다.  
sticky은 부모요소를 기준으로 적용이 된다는 점을 고려하여 이미지로고가 밖인 헤더부분과 카테고리 목록인 nav를 분리하여 적용시켜 스크롤 할 때페이지 상단에 고정되게 하였다.
sticky를 사용함과 동시에 요소가 쌓이게 되어 스크롤시 상단바를 최상위로 고정하기 위해 z-index:1 을 주어 해결을 하였다.

<br />

## :: 기타 질문 및 특이 사항

