### PR TITLE
[27기 구유진] 상단헤더 로그아웃 버그 해결

### DIFF
--- a/src/components/Header/AfterLogin/AfterLogin.js
+++ b/src/components/Header/AfterLogin/AfterLogin.js
@@ -2,13 +2,18 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import './AfterLogin.scss';
 
-function AfterLogin({ userName }) {
+function AfterLogin({ userName, setIsLogin }) {
+  const goingTologout = () => {
+    setIsLogin(false);
+    sessionStorage.clear();
+  };
+
   return (
     <div className="afterLogin">
       <Link className="showUserName" to="/">
         {userName}님
       </Link>
-      <Link className="logOut" to="/" onClick={() => sessionStorage.clear()}>
+      <Link className="logOut" to="/" onClick={goingTologout}>
         로그아웃
       </Link>
     </div>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,32 +1,30 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import BeforeLogin from './BeforeLogin/BeforeLogin';
 import AfterLogin from './AfterLogin/AfterLogin';
 import './Header.scss';
 
 function Header() {
-  //TODO: API통신때는 불필요하기 때문에 삭제 필요
-  sessionStorage.test = '123';
-  sessionStorage.setItem('token', 'ddd');
-  sessionStorage.setItem('username', '구유진');
+  const [isLogin, setIsLogin] = useState(false);
 
-  const isLogin = useRef();
   const userName = useRef();
-
   const location = useLocation();
+
   useEffect(() => {
-    isLogin.current = sessionStorage.getItem('token');
+    if (!!sessionStorage.getItem('token')) {
+      setIsLogin(true);
+    }
     userName.current = sessionStorage.getItem('username');
-  }, [location]);
+  }, [location, isLogin]);
 
   return (
     <div className="header">
       <header className="headerContainer">
         <div className="join">
-          {!isLogin.current ? (
+          {!isLogin ? (
             <BeforeLogin />
           ) : (
-            <AfterLogin userName={userName.current} />
+            <AfterLogin userName={userName.current} setIsLogin={setIsLogin} />
           )}
         </div>
         <div className="navLogo">


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 헤더부분에서 로그인 버튼을 누르고 로그아웃 버튼을 누르면 세션스토리지가 리셋되게 하기

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 이전 코드에서는 로그아웃 버튼을 누르면 2번 눌러야지만 로그아웃이 되어서 로그인의 상태값을 state로 담아서 확인하게 하는 방법으로 로직을 변경하였다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 로그인 했다는 state를 만들어서 true면은 로그인한 상태이고, 그렇지 않으면 로그아웃 상태(false)이기 때문에 이 상태값을 이용하여
코드를 줄일 수 있었다. 

<br />

## :: 기타 질문 및 특이 사항

