### PR TITLE
[27기 김성현] 주문 내역 - 비로그인 시 주문내역 가지 못하게 하기

### DIFF
--- a/src/pages/Cart/CartSummary/CartSummary.js
+++ b/src/pages/Cart/CartSummary/CartSummary.js
@@ -1,15 +1,26 @@
 import React from 'react';
 import { GrLocation } from 'react-icons/gr';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import './CartSummary.scss';
 
 function CartSummary({ items, orderItems }) {
+  const navigate = useNavigate();
+  const token = sessionStorage.getItem('token');
   const total = items.reduce((previousTotal, currentItem) => {
     if (currentItem.notChecked) {
       return previousTotal;
     }
     return previousTotal + currentItem.quantity * currentItem.product_price;
   }, 0);
+
+  const gotoOrderPage = () => {
+    if (!token) {
+      alert('로그인해주세요^^');
+      return;
+    } else {
+      navigate('/order');
+    }
+  };
 
   return (
     <div className="cartSummery">
@@ -33,9 +44,9 @@ function CartSummary({ items, orderItems }) {
       <button className="orderBtn" onClick={orderItems}>
         주문하기
       </button>
-      <Link to="/order">
-        <button className="toOrderPageBtn">주문 내역</button>
-      </Link>
+      <button className="toOrderPageBtn" onClick={gotoOrderPage}>
+        주문 내역
+      </button>
     </div>
   );
 }

--- a/src/pages/ProductDetail/ProductInformation/ProductInformation.js
+++ b/src/pages/ProductDetail/ProductInformation/ProductInformation.js
@@ -30,7 +30,7 @@ function ProductInformation({
       fetch(API.cart, {
         method: 'POST',
         headers: {
-          authorization: token,
+          Authorization: token,
         },
         body: JSON.stringify({
           product_id: productId,


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 로그인 되어있지 않을 때 장바구니 페이지에서 주문 내역 버튼 누르면 주문내역으로 가지 않게 하기
- Autoriztion -> autoriztion 으로 키 이름 변경
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 장바구니 페이지에 있는 주문내역 버튼을 클릭시 
-> 로그인 되었을 때 - 주문 내역 페이지로 가게 하기
-> 로그인 되지 않았을 때 - 로그인 해달라는 알림창 뜨게하기

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

<br />

## :: 기타 질문 및 특이 사항

